### PR TITLE
Add en_AU user locale.

### DIFF
--- a/yodlee-api-model/src/main/java/com/yodlee/api/model/user/enums/Locale.java
+++ b/yodlee-api-model/src/main/java/com/yodlee/api/model/user/enums/Locale.java
@@ -21,5 +21,9 @@ public enum Locale {
 	/**
 	 * Chinese - China
 	 */
-	zh_CN;
+	zh_CN,
+	/**
+	 * English - Australia
+	 */
+	en_AU;
 }


### PR DESCRIPTION
The Australia Yodlee API endpoint is setting User locales to en_AU.  This allows the SDK to handle that.